### PR TITLE
chore(next.config.js): replaces domains with remotePatterns

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,16 @@ const nextConfig = {
     removeConsole: true,
   },
   images: {
-    remotePatterns: ['uploadthing.com', 'lh3.googleusercontent.com'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'uploadthing.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+      },
+    ],
   },
 };
 

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,7 @@ const nextConfig = {
     removeConsole: true,
   },
   images: {
-    domains: ['uploadthing.com', 'lh3.googleusercontent.com'],
+    remotePatterns: ['uploadthing.com', 'lh3.googleusercontent.com'],
   },
 };
 


### PR DESCRIPTION
```
images:{
    domains:[ ... ]
} is deprecated
```